### PR TITLE
adding support for shallow clones of objects/arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,16 +18,26 @@ module.exports = clone;
 /**
  * Clones objects.
  *
- * @param {Mixed} any object
+ * @param {Mixed} obj          any object
+ * @param {Boolean} [shallow]  whether to shallow clone only
  * @api public
  */
 
-function clone(obj){
+function clone(obj, shallow){
   switch (type(obj)) {
     case 'object':
       var copy = {};
       for (var key in obj) {
         if (obj.hasOwnProperty(key)) {
+          if (shallow) {
+            switch (type(obj[key])) {
+              case 'object':
+              case 'array':
+                copy[key] = obj[key];
+                continue;
+            }
+          }
+
           copy[key] = clone(obj[key]);
         }
       }
@@ -36,6 +46,15 @@ function clone(obj){
     case 'array':
       var copy = new Array(obj.length);
       for (var i = 0, l = obj.length; i < l; i++) {
+        if (shallow) {
+          switch (type(obj[i])) {
+            case 'object':
+            case 'array':
+              copy[i] = obj[i];
+              continue;
+          }
+        }
+
         copy[i] = clone(obj[i]);
       }
       return copy;

--- a/test/clone.js
+++ b/test/clone.js
@@ -77,4 +77,36 @@ describe('clone', function(){
     expect(func()).to.be('original');
   });
 
+  describe('shallow cloning', function () {
+    var now = new Date();
+
+    it('should work with objects', function () {
+      var o = {
+        regex: /foo/,
+        bool: true,
+        date: now,
+        number: 5.0,
+        object: {
+          bool: false
+        }
+      };
+
+      var cloned = clone(o, true);
+
+      expect(cloned).to.eql(o);
+      expect(cloned.date).to.not.be(o.date);
+      expect(cloned.regex).to.not.be(o.regex);
+      expect(cloned.object).to.equal(o.object);
+    });
+
+    it('should work with arrays', function () {
+      var o = [ /foo/, true, now, 5.0, { bool: false } ]
+      var cloned = clone(o, true);
+
+      expect(cloned).to.eql(o);
+      expect(cloned[0]).to.not.be(o[0]);
+      expect(cloned[2]).to.not.be(o[2]);
+      expect(cloned[4]).to.equal(o[4]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #7 and adds support for shallow-cloning arrays/objects.

This change is fully backwards-compatible, it simply adds another argument/flag. (tests included)
